### PR TITLE
Several bug fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CXX := g++-4.9
+#CXX := g++-4.9
+CXX := g++
 CXXFLAGS := -std=c++14 -Wall -g -pedantic-errors -Werror -O3 \
 						-Wno-unused-parameter -Wextra -Weffc++
 # REPLAY := yes enables a policy that can feed traces to memcached, but it

--- a/src/lsm-sim.cpp
+++ b/src/lsm-sim.cpp
@@ -476,6 +476,7 @@ int main(int argc, char *argv[]) {
       }
       sts.memcachier_classes = memcachier_classes;
       policy.reset(new shadowslab(sts));
+      break;
     case PARTSLAB:
       sts.partitions = partitions;
       policy.reset(new partslab(sts));

--- a/src/policy.h
+++ b/src/policy.h
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "request.h"
 #include "stats.h"
+#include <iostream>
 
 // abstract base class for plug-and-play policies
 class policy {
@@ -30,7 +31,7 @@ class policy {
   public:
     policy(stats stat)
       : stat{stat}
-      , all_apps{stat.apps->empty()}
+      , all_apps{!stat.apps ? false : stat.apps->empty()}
     {}
 
     virtual ~policy() {}
@@ -40,7 +41,7 @@ class policy {
 
     virtual size_t get_bytes_cached() const = 0; 
 
-    void log_curves() { std::cout << "Not enabled for this policy" 
+    virtual void log_curves() { std::cout << "Not enabled for this policy" 
       << std::endl; }
 
     stats* get_stats() { return &stat; }

--- a/src/shadowslab.cpp
+++ b/src/shadowslab.cpp
@@ -39,6 +39,9 @@ shadowslab::~shadowslab() {
 size_t shadowslab::proc(const request *r, bool warmup) {
   assert(r->size() > 0);
 
+  if (!warmup) {
+    ++stat.accesses;
+  }
   uint64_t class_size = 0;
   uint64_t klass = 0;
   std::tie(class_size, klass) = get_slab_class(r->size());
@@ -96,8 +99,10 @@ size_t shadowslab::proc(const request *r, bool warmup) {
 
   size_t approx_global_size_distance =
      (slabid * SLABSIZE) + (size_distance % SLABSIZE);
-  if (!warmup)
+  if (!warmup) {
     size_curve.hit(approx_global_size_distance);
+    ++stat.hits;
+  }
 
   return 0;
 }


### PR DESCRIPTION
This PR has the following bugs fixed:
- Makefile was using g++-4.9, changed it to g++ to make it compatible with newer g++ versions.
- lsm-sim.cpp was missing a break statement in switch-case block thus running into the next case statement.
- policy.h was missing iostream header which was breaking compilation.
- policy.h checking for NULL stat.apps before checking it is empty. This was causing a crash for shadowslab policy.
- Made log_curves() function in policy.h virtual so that the corresponding function from shadowslab.cpp can be invoked when shadowslab policy is executed.
- Added stat.accesses and stat.hits in shadowslab.cpp to generate correct hit_rate number. 
